### PR TITLE
Add an Audio Work Type

### DIFF
--- a/app/actors/hyrax/actors/audio_actor.rb
+++ b/app/actors/hyrax/actors/audio_actor.rb
@@ -1,0 +1,8 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  module Actors
+    class AudioActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/controllers/hyrax/audios_controller.rb
+++ b/app/controllers/hyrax/audios_controller.rb
@@ -1,0 +1,14 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  # Generated controller for Audio
+  class AudiosController < ApplicationController
+    # Adds Hyrax behaviors to the controller.
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    self.curation_concern_type = ::Audio
+
+    # Use this line if you want to use a custom presenter
+    self.show_presenter = Hyrax::AudioPresenter
+  end
+end

--- a/app/forms/hyrax/audio_form.rb
+++ b/app/forms/hyrax/audio_form.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  # Generated form for Audio
+  class AudioForm < Hyrax::Forms::WorkForm
+    self.model_class = ::Audio
+    self.terms += [:resource_type]
+  end
+end

--- a/app/indexers/audio_indexer.rb
+++ b/app/indexers/audio_indexer.rb
@@ -1,0 +1,18 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+class AudioIndexer < Hyrax::WorkIndexer
+  # This indexes the default metadata. You can remove it if you want to
+  # provide your own metadata and indexing.
+  include Hyrax::IndexesBasicMetadata
+
+  # Fetch remote labels for based_near. You can remove this if you don't want
+  # this behavior
+  include Hyrax::IndexesLinkedMetadata
+
+  # Uncomment this block if you want to add custom indexing behavior:
+  # def generate_solr_document
+  #  super.tap do |solr_doc|
+  #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
+  #  end
+  # end
+end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -1,0 +1,14 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+class Audio < ActiveFedora::Base
+  include ::Hyrax::WorkBehavior
+
+  self.indexer = AudioIndexer
+  # Change this to restrict which works can be added as a child.
+  # self.valid_child_concerns = []
+  validates :title, presence: { message: 'Your work must have a title.' }
+
+  # This must be included at the end, because it finalizes the metadata
+  # schema (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
+end

--- a/app/presenters/hyrax/audio_presenter.rb
+++ b/app/presenters/hyrax/audio_presenter.rb
@@ -1,0 +1,6 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+module Hyrax
+  class AudioPresenter < Hyrax::WorkShowPresenter
+  end
+end

--- a/app/views/hyrax/audios/_audio.html.erb
+++ b/app/views/hyrax/audios/_audio.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: audio, document_counter: audio_counter  %>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -1,6 +1,8 @@
 Hyrax.config do |config|
   # Injected via `rails g hyrax:work Image`
   config.register_curation_concern :image
+  # Injected via `rails g hyrax:work Audio`
+  config.register_curation_concern :audio
   # Register roles that are expected by your implementation.
   # @see Hyrax::RoleRegistry for additional details.
   # @note there are magical roles as defined in Hyrax::RoleRegistry::MAGIC_ROLES

--- a/config/locales/audio.de.yml
+++ b/config/locales/audio.de.yml
@@ -1,0 +1,8 @@
+de:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio Werke"
+        name:               "Audio"

--- a/config/locales/audio.en.yml
+++ b/config/locales/audio.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio works"
+        name:               "Audio"

--- a/config/locales/audio.es.yml
+++ b/config/locales/audio.es.yml
@@ -1,0 +1,10 @@
+es:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        # TODO: translate `human_name` into Spanish
+        description:        "Audio trabajos"
+        name:               "Audio"
+        # TODO: translate `human_name` into Spanish

--- a/config/locales/audio.fr.yml
+++ b/config/locales/audio.fr.yml
@@ -1,0 +1,8 @@
+fr:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio œuvres"
+        name:               "Audio"

--- a/config/locales/audio.it.yml
+++ b/config/locales/audio.it.yml
@@ -1,0 +1,8 @@
+it:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio opere"
+        name:               "Audio"

--- a/config/locales/audio.pt-BR.yml
+++ b/config/locales/audio.pt-BR.yml
@@ -1,0 +1,8 @@
+pt-BR:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        description:        "Audio trabalhos"
+        name:               "Audio"

--- a/config/locales/audio.zh.yml
+++ b/config/locales/audio.zh.yml
@@ -1,0 +1,10 @@
+zh:
+  hyrax:
+    icons:
+      audio:     'fa fa-file-text-o'
+    select_type:
+      audio:
+        # TODO: translate `human_name` into Chinese
+        description:        "Audio 作品"
+        name:               "Audio"
+        # TODO: translate `human_name` into Chinese

--- a/spec/actors/hyrax/actors/audio_actor_spec.rb
+++ b/spec/actors/hyrax/actors/audio_actor_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::Actors::AudioActor do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/controllers/hyrax/audios_controller_spec.rb
+++ b/spec/controllers/hyrax/audios_controller_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::AudiosController do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/forms/hyrax/audio_form_spec.rb
+++ b/spec/forms/hyrax/audio_form_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::AudioForm do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/models/audio_spec.rb
+++ b/spec/models/audio_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Audio do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/presenters/hyrax/audio_presenter_spec.rb
+++ b/spec/presenters/hyrax/audio_presenter_spec.rb
@@ -1,0 +1,9 @@
+# Generated via
+#  `rails generate hyrax:work Audio`
+require 'rails_helper'
+
+RSpec.describe Hyrax::AudioPresenter do
+  it "has tests" do
+    skip "Add your tests here"
+  end
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,28 @@
+# Setup chrome headless driver
+Capybara.server = :puma, { Silent: true }
+
+Capybara.register_driver :chrome_headless do |app|
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  client.read_timeout = 120
+
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  # options.add_argument('--headless')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--window-size=1400,1400')
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options, http_client: client)
+end
+
+Capybara.javascript_driver = :chrome_headless
+
+# Setup rspec
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :chrome_headless
+  end
+end

--- a/spec/system/create_audio_spec.rb
+++ b/spec/system/create_audio_spec.rb
@@ -1,10 +1,10 @@
 # Generated via
-#  `rails generate hyrax:work Image`
+#  `rails generate hyrax:work Audio`
 require 'rails_helper'
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Image', js: false do
+RSpec.describe 'Create a Audio', integration: true, clean: true, type: :system do
   context 'a logged in user' do
     let(:user_attributes) do
       { email: 'test@example.com' }
@@ -36,10 +36,10 @@ RSpec.feature 'Create a Image', js: false do
       click_link "Add new work"
 
       # If you generate more than one work uncomment these lines
-      # choose "payload_concern", option: "Image"
-      # click_button "Create work"
+      choose "payload_concern", option: "Audio"
+      click_button "Create work"
 
-      expect(page).to have_content "Add New Image"
+      expect(page).to have_content "Add New Audio"
       click_link "Files" # switch tab
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
@@ -52,14 +52,12 @@ RSpec.feature 'Create a Image', js: false do
       fill_in('Creator', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
-      click_link("Additional fields")
-      fill_in "Year", with: "2005"
 
       # With selenium and the chrome driver, focus remains on the
       # select box. Click outside the box so the next line can't find
       # its element
       find('body').click
-      choose('image_visibility_open')
+      choose('audio_visibility_open')
       expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
       check('agreement')
 

--- a/spec/system/create_image_spec.rb
+++ b/spec/system/create_image_spec.rb
@@ -1,0 +1,71 @@
+# Generated via
+#  `rails generate hyrax:work Image`
+require 'rails_helper'
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.describe 'Create a Image', type: :system do
+  context 'a logged in user' do
+    let(:user_attributes) do
+      { email: 'test@example.com' }
+    end
+    let(:user) do
+      User.new(user_attributes) { |u| u.save(validate: false) }
+    end
+    let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+    let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+    let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+
+    before do
+      # Create a single action that can be taken
+      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user.user_key,
+        access: 'deposit'
+      )
+      login_as user
+    end
+
+    scenario do
+      visit '/dashboard'
+      click_link "Works"
+      click_link "Add new work"
+
+      # If you generate more than one work uncomment these lines
+      choose "payload_concern", option: "Image"
+      click_button "Create work"
+
+      expect(page).to have_content "Add New Image"
+      click_link "Files" # switch tab
+      expect(page).to have_content "Add files"
+      expect(page).to have_content "Add folder"
+      within('span#addfiles') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/jp2_fits.xml", visible: false)
+      end
+      click_link "Descriptions" # switch tab
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Creator', with: 'Doe, Jane')
+      fill_in('Keyword', with: 'testing')
+      select('In Copyright', from: 'Rights statement')
+      click_link("Additional fields")
+      fill_in "Year", with: "2005"
+
+      # With selenium and the chrome driver, focus remains on the
+      # select box. Click outside the box so the next line can't find
+      # its element
+      find('body').click
+      choose('image_visibility_open')
+      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      check('agreement')
+
+      click_on('Save')
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content "Your files are being processed by Hyrax in the background."
+    end
+  end
+end

--- a/spec/system/search_image_spec.rb
+++ b/spec/system/search_image_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Search for an image' do
+RSpec.describe 'Search for an image', type: :system do
   let(:title) { ['Journey to Skull Island'] }
   let(:creator) { ['Quest, Jane'] }
   let(:keyword) { ['Pirates', 'Adventure'] }

--- a/spec/system/show_image_spec.rb
+++ b/spec/system/show_image_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Display an Image' do
+RSpec.describe 'Display an Image', type: :system do
   let(:title)      { ['Journey to Skull Island'] }
   let(:creator)    { ['Quest, Jane'] }
   let(:keyword)    { ['Pirates', 'Adventure'] }


### PR DESCRIPTION
Added new work type - "Audio"

Changed feature tests to system tests
- renamed spec/feature directory to "spec/system"
- added support folder to spec directory
- modeled after Emory DLP Curate: https://github.com/emory-libraries/dlp-curate/blob/master/spec/support/capybara.rb
- article resource: https://everydayrails.com/2018/01/08/rspec-3.7-system-tests.html

For new spec files, please follow directions in article; some syntax changes required.