### PR TITLE
Add year metadata field to audio work type

### DIFF
--- a/app/forms/hyrax/audio_form.rb
+++ b/app/forms/hyrax/audio_form.rb
@@ -5,5 +5,6 @@ module Hyrax
   class AudioForm < Hyrax::Forms::WorkForm
     self.model_class = ::Audio
     self.terms += [:resource_type]
+    self.terms += [:year]
   end
 end

--- a/app/models/audio.rb
+++ b/app/models/audio.rb
@@ -8,6 +8,10 @@ class Audio < ActiveFedora::Base
   # self.valid_child_concerns = []
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  property :year, predicate: "http://www.europeana.eu/schemas/edm/year" do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/presenters/hyrax/audio_presenter.rb
+++ b/app/presenters/hyrax/audio_presenter.rb
@@ -1,6 +1,13 @@
 # Generated via
 #  `rails generate hyrax:work Audio`
+require 'numbers_in_words'
+
 module Hyrax
   class AudioPresenter < Hyrax::WorkShowPresenter
+    delegate :year, to: :solr_document
+
+    def year_into_words
+      NumbersInWords.in_words(year.first)
+    end
   end
 end


### PR DESCRIPTION
Add year to audio work type, so that displaying the year in words works for both our image and audio work types